### PR TITLE
#417: Normalize legacy access-store paths to absolute paths

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -11,6 +11,7 @@
 
 * #413: Fixed Luigi signal handling in notebook DockerDB startup and SLC build
 * #416: Fixed wrong access store search path in `first_steps.ipynb`
+* #417: Normalized access-store notebook paths and exported `NOTEBOOKS` from `ai-lab start`
 
 ## Refactorings
 

--- a/doc/user_guide/ai-lab-cli.rst
+++ b/doc/user_guide/ai-lab-cli.rst
@@ -28,7 +28,8 @@ Command ``start``
 
 Command ``start`` launches JupyterLab by invoking ``python -m jupyter lab``.
 Before JupyterLab starts, Notebook Connector copies the bundled notebooks into
-the notebook root directory leaving existing files unchanged.
+the notebook root directory leaving existing files unchanged, and exports
+``NOTEBOOKS`` for the launched JupyterLab session.
 
 .. code-block:: shell
 

--- a/exasol/nb_connector/cli/commands/ai_lab.py
+++ b/exasol/nb_connector/cli/commands/ai_lab.py
@@ -19,6 +19,7 @@ Deploy the bundled notebooks to a local directory:
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess  # nosec: B404
 import sys
@@ -141,7 +142,9 @@ def start(port: int, ip: str, notebook_dir: Path | None, no_browser: bool) -> No
 
     click.echo(f"Starting JupyterLab on http://{ip}:{port} (notebook dir: {root})")
     try:
-        subprocess.run(cmd, check=True)  # nosec: B603
+        env = os.environ.copy()
+        env["NOTEBOOKS"] = str(root)
+        subprocess.run(cmd, check=True, env=env)  # nosec: B603
     except KeyboardInterrupt:
         click.echo("\nJupyterLab stopped")
 

--- a/exasol/nb_connector/ui/access/access_store.py
+++ b/exasol/nb_connector/ui/access/access_store.py
@@ -28,9 +28,9 @@ def _get_scs_path_base(root_dir: str | None) -> Path:
             return _normalize_path_lexically(root_dir_path)
         return _normalize_path_lexically(Path.cwd() / root_dir_path)
 
-    notebook_dir = os.environ.get("NOTEBOOK_DIR")
-    if notebook_dir:
-        return _normalize_path_lexically(notebook_dir)
+    notebooks_dir = os.environ.get("NOTEBOOKS")
+    if notebooks_dir:
+        return _normalize_path_lexically(notebooks_dir)
 
     return _normalize_path_lexically(Path.cwd())
 

--- a/exasol/nb_connector/ui/access/access_store.py
+++ b/exasol/nb_connector/ui/access/access_store.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import ipywidgets as widgets
@@ -20,11 +21,31 @@ def get_scs_location_file_path() -> Path:
     return Path.home() / ".cache" / "notebook-connector" / "scs_file"
 
 
-def _resolve_scs_file_path(root_dir: str, scs_file: str | Path) -> Path:
+def _get_scs_path_base(root_dir: str | None) -> Path:
+    if root_dir is not None:
+        return Path(root_dir)
+
+    notebook_dir = os.environ.get("NOTEBOOK_DIR")
+    if notebook_dir:
+        return Path(notebook_dir)
+
+    return Path.cwd()
+
+
+def _resolve_scs_file_path(root_dir: str | None, scs_file: str | Path) -> Path:
     path = Path(scs_file)
     if path.is_absolute():
         return path.resolve()
-    return (Path(root_dir) / path).resolve()
+    return (_get_scs_path_base(root_dir) / path).resolve()
+
+
+def _display_scs_file_path(root_dir: str | None, scs_file: str | Path) -> str:
+    base_dir = _get_scs_path_base(root_dir).resolve()
+    resolved_path = _resolve_scs_file_path(root_dir, scs_file)
+    try:
+        return str(resolved_path.relative_to(base_dir))
+    except ValueError:
+        return str(resolved_path)
 
 
 def get_sb_store_file():
@@ -39,8 +60,11 @@ def set_sb_store_file(value):
     get_scs_location_file_path().write_text(value)
 
 
-def get_access_store(root_dir: str = ".") -> widgets.Widget:
-    sb_store_file_ = _resolve_scs_file_path(root_dir, get_sb_store_file())
+def get_access_store(root_dir: str | None = None) -> widgets.Widget:
+    sb_store_file = get_sb_store_file()
+    sb_store_file_ = _resolve_scs_file_path(root_dir, sb_store_file)
+    if not Path(sb_store_file).is_absolute():
+        set_sb_store_file(str(sb_store_file_))
     ui_look = config_styles()
 
     header_lbl = widgets.Label(
@@ -55,7 +79,7 @@ def get_access_store(root_dir: str = ".") -> widgets.Widget:
         value="Password", style=ui_look.label_style, layout=ui_look.label_layout
     )
     file_txt = widgets.Text(
-        value=str(sb_store_file_),
+        value=_display_scs_file_path(root_dir, sb_store_file_),
         style=ui_look.input_style,
         layout=ui_look.input_layout,
     )
@@ -68,6 +92,7 @@ def get_access_store(root_dir: str = ".") -> widgets.Widget:
 
     def open_or_create_config_store(btn):
         sb_store_file = _resolve_scs_file_path(root_dir, file_txt.value)
+        file_txt.value = _display_scs_file_path(root_dir, sb_store_file)
         ipython = get_ipython()
         try:
             ai_lab_config = Secrets(sb_store_file, password_txt.value)

--- a/exasol/nb_connector/ui/access/access_store.py
+++ b/exasol/nb_connector/ui/access/access_store.py
@@ -25,14 +25,14 @@ def _get_scs_path_base(root_dir: str | None) -> Path:
     if root_dir is not None:
         root_dir_path = Path(root_dir)
         if root_dir_path.is_absolute():
-            return _normalize_path_lexically(root_dir_path)
-        return _normalize_path_lexically(Path.cwd() / root_dir_path)
+            return root_dir_path
+        return Path.cwd() / root_dir_path
 
     notebooks_dir = os.environ.get("NOTEBOOKS")
     if notebooks_dir:
-        return _normalize_path_lexically(notebooks_dir)
+        return Path(notebooks_dir)
 
-    return _normalize_path_lexically(Path.cwd())
+    return Path.cwd()
 
 
 def _normalize_path_lexically(path: str | Path) -> Path:
@@ -44,14 +44,14 @@ def _normalize_path_lexically(path: str | Path) -> Path:
 def _resolve_scs_file_path(root_dir: str | None, scs_file: str | Path) -> Path:
     path = os.fspath(scs_file)
     if os.path.isabs(path):
-        return _normalize_path_lexically(path)
-    base_dir = os.fspath(_get_scs_path_base(root_dir))
-    return _normalize_path_lexically(os.path.join(base_dir, path))
+        return Path(path)
+    base_dir = _get_scs_path_base(root_dir)
+    return base_dir / path
 
 
 def _display_scs_file_path(root_dir: str | None, scs_file: str | Path) -> str:
     base_dir = _normalize_path_lexically(_get_scs_path_base(root_dir))
-    resolved_path = _resolve_scs_file_path(root_dir, scs_file)
+    resolved_path = _normalize_path_lexically(_resolve_scs_file_path(root_dir, scs_file))
     try:
         return str(resolved_path.relative_to(base_dir))
     except ValueError:
@@ -99,7 +99,9 @@ def get_access_store(root_dir: str | None = None) -> widgets.Widget:
     )
 
     def open_or_create_config_store(btn):
-        sb_store_file = _resolve_scs_file_path(root_dir, file_txt.value)
+        sb_store_file = _normalize_path_lexically(
+            _resolve_scs_file_path(root_dir, file_txt.value)
+        )
         file_txt.value = _display_scs_file_path(root_dir, sb_store_file)
         ipython = get_ipython()
         try:

--- a/exasol/nb_connector/ui/access/access_store.py
+++ b/exasol/nb_connector/ui/access/access_store.py
@@ -23,24 +23,34 @@ def get_scs_location_file_path() -> Path:
 
 def _get_scs_path_base(root_dir: str | None) -> Path:
     if root_dir is not None:
-        return Path(root_dir)
+        root_dir_path = Path(root_dir)
+        if root_dir_path.is_absolute():
+            return _normalize_path_lexically(root_dir_path)
+        return _normalize_path_lexically(Path.cwd() / root_dir_path)
 
     notebook_dir = os.environ.get("NOTEBOOK_DIR")
     if notebook_dir:
-        return Path(notebook_dir)
+        return _normalize_path_lexically(notebook_dir)
 
-    return Path.cwd()
+    return _normalize_path_lexically(Path.cwd())
+
+
+def _normalize_path_lexically(path: str | Path) -> Path:
+    # Normalize lexically without resolving symlinks or touching the filesystem, to avoid
+    # constructing paths from user-controlled input with Path.resolve().
+    return Path(os.path.normpath(os.fspath(path)))
 
 
 def _resolve_scs_file_path(root_dir: str | None, scs_file: str | Path) -> Path:
-    path = Path(scs_file)
-    if path.is_absolute():
-        return path.resolve()
-    return (_get_scs_path_base(root_dir) / path).resolve()
+    path = os.fspath(scs_file)
+    if os.path.isabs(path):
+        return _normalize_path_lexically(path)
+    base_dir = os.fspath(_get_scs_path_base(root_dir))
+    return _normalize_path_lexically(os.path.join(base_dir, path))
 
 
 def _display_scs_file_path(root_dir: str | None, scs_file: str | Path) -> str:
-    base_dir = _get_scs_path_base(root_dir).resolve()
+    base_dir = _normalize_path_lexically(_get_scs_path_base(root_dir))
     resolved_path = _resolve_scs_file_path(root_dir, scs_file)
     try:
         return str(resolved_path.relative_to(base_dir))

--- a/exasol/nb_connector/ui/access/access_store.py
+++ b/exasol/nb_connector/ui/access/access_store.py
@@ -20,6 +20,13 @@ def get_scs_location_file_path() -> Path:
     return Path.home() / ".cache" / "notebook-connector" / "scs_file"
 
 
+def _resolve_scs_file_path(root_dir: str, scs_file: str | Path) -> Path:
+    path = Path(scs_file)
+    if path.is_absolute():
+        return path.resolve()
+    return (Path(root_dir) / path).resolve()
+
+
 def get_sb_store_file():
     try:
         return get_scs_location_file_path().read_text().strip()
@@ -33,7 +40,7 @@ def set_sb_store_file(value):
 
 
 def get_access_store(root_dir: str = ".") -> widgets.Widget:
-    sb_store_file_ = get_sb_store_file()
+    sb_store_file_ = _resolve_scs_file_path(root_dir, get_sb_store_file())
     ui_look = config_styles()
 
     header_lbl = widgets.Label(
@@ -48,7 +55,9 @@ def get_access_store(root_dir: str = ".") -> widgets.Widget:
         value="Password", style=ui_look.label_style, layout=ui_look.label_layout
     )
     file_txt = widgets.Text(
-        value=sb_store_file_, style=ui_look.input_style, layout=ui_look.input_layout
+        value=str(sb_store_file_),
+        style=ui_look.input_style,
+        layout=ui_look.input_layout,
     )
     password_txt = widgets.Password(
         style=ui_look.input_style, layout=ui_look.input_layout
@@ -58,10 +67,10 @@ def get_access_store(root_dir: str = ".") -> widgets.Widget:
     )
 
     def open_or_create_config_store(btn):
-        sb_store_file = file_txt.value
+        sb_store_file = _resolve_scs_file_path(root_dir, file_txt.value)
         ipython = get_ipython()
         try:
-            ai_lab_config = Secrets(Path(root_dir) / sb_store_file, password_txt.value)
+            ai_lab_config = Secrets(sb_store_file, password_txt.value)
             ai_lab_config.connection()
         except InvalidPassword:
             display_popup(
@@ -71,7 +80,7 @@ def get_access_store(root_dir: str = ".") -> widgets.Widget:
             open_btn.icon = "check"
             ipython.push({"ai_lab_config": ai_lab_config}, interactive=True)
         finally:
-            set_sb_store_file(sb_store_file)
+            set_sb_store_file(str(sb_store_file))
 
     def on_value_change(change):
         open_btn.icon = "pen"

--- a/exasol/nb_connector/ui/access/access_store.py
+++ b/exasol/nb_connector/ui/access/access_store.py
@@ -51,7 +51,9 @@ def _resolve_scs_file_path(root_dir: str | None, scs_file: str | Path) -> Path:
 
 def _display_scs_file_path(root_dir: str | None, scs_file: str | Path) -> str:
     base_dir = _normalize_path_lexically(_get_scs_path_base(root_dir))
-    resolved_path = _normalize_path_lexically(_resolve_scs_file_path(root_dir, scs_file))
+    resolved_path = _normalize_path_lexically(
+        _resolve_scs_file_path(root_dir, scs_file)
+    )
     try:
         return str(resolved_path.relative_to(base_dir))
     except ValueError:

--- a/exasol/nb_connector/ui/access/access_store.py
+++ b/exasol/nb_connector/ui/access/access_store.py
@@ -63,8 +63,6 @@ def set_sb_store_file(value):
 def get_access_store(root_dir: str | None = None) -> widgets.Widget:
     sb_store_file = get_sb_store_file()
     sb_store_file_ = _resolve_scs_file_path(root_dir, sb_store_file)
-    if not Path(sb_store_file).is_absolute():
-        set_sb_store_file(str(sb_store_file_))
     ui_look = config_styles()
 
     header_lbl = widgets.Label(

--- a/test/integration/ui/access/test_access_store.py
+++ b/test/integration/ui/access/test_access_store.py
@@ -94,7 +94,11 @@ def test_access_store_sets_ai_lab_config_in_ipython(tmp_path):
     nb = nbformat.v4.new_notebook()
     nb.cells = [
         nbformat.v4.new_code_cell(f"""
+            from pathlib import Path
+            import exasol.nb_connector.ui.access.access_store as access_ui
             from exasol.nb_connector.ui.access.access_store import get_access_store
+
+            access_ui.get_scs_location_file_path = lambda: Path("{store_dir}") / "scs_file"
             
             ui = get_access_store("{store_dir}")
             display(ui)

--- a/test/integration/ui/transformers/util/test_te_init_ui.py
+++ b/test/integration/ui/transformers/util/test_te_init_ui.py
@@ -19,8 +19,12 @@ def test_te_init_ui_save_token(tmp_path):
         nbformat.v4.new_code_cell(
             # loading the ai_lab_config via access_store_ui
             f"""
+            from pathlib import Path
             from IPython.display import display
+            import exasol.nb_connector.ui.access.access_store as access_ui
             from exasol.nb_connector.ui.access.access_store import get_access_store
+
+            access_ui.get_scs_location_file_path = lambda: Path("{store_dir}") / "scs_file"
             
             ui = get_access_store("{store_dir}")
             display(ui)

--- a/test/unit/cli/test_ai_lab.py
+++ b/test/unit/cli/test_ai_lab.py
@@ -79,6 +79,7 @@ def test_start_success(mock_run, mock_check, mock_deploy, runner, notebooks_dir)
     mock_deploy.assert_called_once_with(notebooks_dir, overwrite=False)
     mock_run.assert_called_once()
     called_cmd = mock_run.call_args[0][0]
+    assert mock_run.call_args.kwargs["env"]["NOTEBOOKS"] == str(notebooks_dir)
     assert "lab" in called_cmd
     assert "--no-browser" in called_cmd
 
@@ -168,6 +169,7 @@ def test_start_without_notebook_dir_uses_current_working_dir(
     mock_cwd.assert_called_once()
     mock_deploy.assert_called_once_with(default_dir, overwrite=False)
     called_cmd = mock_run.call_args[0][0]
+    assert mock_run.call_args.kwargs["env"]["NOTEBOOKS"] == str(default_dir)
     assert f"--notebook-dir={default_dir}" in called_cmd
 
 

--- a/test/unit/ui/access/test_access_store.py
+++ b/test/unit/ui/access/test_access_store.py
@@ -58,6 +58,7 @@ def test_access_store_legacy_relative_path_is_upgraded_to_absolute(
     file_name_field = ui.children[0].children[1].children[1]
     expected_absolute_path = str((tmp_path / legacy_relative_path).resolve())
     assert file_name_field.value == legacy_relative_path
+    assert test_scs_file.read_text().strip() == legacy_relative_path
 
     password_field = ui.children[0].children[2].children[1]
     password_field.value = "password"

--- a/test/unit/ui/access/test_access_store.py
+++ b/test/unit/ui/access/test_access_store.py
@@ -120,9 +120,10 @@ def test_access_store_relative_root_dir_is_resolved_to_absolute(tmp_path, monkey
         relative_root_dir, relative_file_path
     )
     assert raw_resolved_path == notebooks_dir / ".." / relative_file_path
-    assert access_ui._normalize_path_lexically(raw_resolved_path) == (
-        tmp_path / relative_file_path
-    ).resolve()
+    assert (
+        access_ui._normalize_path_lexically(raw_resolved_path)
+        == (tmp_path / relative_file_path).resolve()
+    )
 
     ui = access_ui.get_access_store(relative_root_dir)
     file_name_field = ui.children[0].children[1].children[1]

--- a/test/unit/ui/access/test_access_store.py
+++ b/test/unit/ui/access/test_access_store.py
@@ -116,6 +116,14 @@ def test_access_store_relative_root_dir_is_resolved_to_absolute(tmp_path, monkey
     relative_file_path = "relative-root.sqlite"
     test_scs_file.write_text(relative_file_path)
 
+    raw_resolved_path = access_ui._resolve_scs_file_path(
+        relative_root_dir, relative_file_path
+    )
+    assert raw_resolved_path == notebooks_dir / ".." / relative_file_path
+    assert access_ui._normalize_path_lexically(raw_resolved_path) == (
+        tmp_path / relative_file_path
+    ).resolve()
+
     ui = access_ui.get_access_store(relative_root_dir)
     file_name_field = ui.children[0].children[1].children[1]
     expected_absolute_path = str((tmp_path / relative_file_path).resolve())

--- a/test/unit/ui/access/test_access_store.py
+++ b/test/unit/ui/access/test_access_store.py
@@ -15,7 +15,7 @@ def test_access_store_ui_store_read_and_write(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
-    monkeypatch.delenv("NOTEBOOK_DIR", raising=False)
+    monkeypatch.delenv("NOTEBOOKS", raising=False)
 
     if test_scs_file.exists():
         test_scs_file.unlink()
@@ -43,13 +43,13 @@ def test_access_store_legacy_relative_path_is_upgraded_to_absolute(
     tmp_path, monkeypatch
 ):
     """
-    Test that a legacy relative cache entry is resolved against NOTEBOOK_DIR and
+    Test that a legacy relative cache entry is resolved against NOTEBOOKS and
     rewritten in absolute form after the store is opened.
     """
     monkeypatch.chdir(tmp_path)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
-    monkeypatch.setenv("NOTEBOOK_DIR", str(tmp_path))
+    monkeypatch.setenv("NOTEBOOKS", str(tmp_path))
 
     legacy_relative_path = "legacy_config.sqlite"
     test_scs_file.write_text(legacy_relative_path)
@@ -72,13 +72,13 @@ def test_access_store_legacy_relative_path_is_upgraded_to_absolute(
 
 def test_access_store_explicit_root_dir_overrides_notebook_dir(tmp_path, monkeypatch):
     """
-    Test that an explicit root_dir is preferred over NOTEBOOK_DIR for display and
+    Test that an explicit root_dir is preferred over NOTEBOOKS for display and
     resolution.
     """
     monkeypatch.chdir(tmp_path)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
-    monkeypatch.setenv("NOTEBOOK_DIR", str(tmp_path / "notebook"))
+    monkeypatch.setenv("NOTEBOOKS", str(tmp_path / "notebook"))
 
     explicit_root_dir = tmp_path / "explicit-root"
     explicit_root_dir.mkdir()
@@ -110,7 +110,7 @@ def test_access_store_relative_root_dir_is_resolved_to_absolute(tmp_path, monkey
     monkeypatch.chdir(notebooks_dir)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
-    monkeypatch.delenv("NOTEBOOK_DIR", raising=False)
+    monkeypatch.delenv("NOTEBOOKS", raising=False)
 
     relative_root_dir = ".."
     relative_file_path = "relative-root.sqlite"
@@ -140,7 +140,7 @@ def test_access_store_absolute_path_outside_base_is_displayed_absolute(
     monkeypatch.chdir(tmp_path)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
-    monkeypatch.setenv("NOTEBOOK_DIR", str(tmp_path / "notebook"))
+    monkeypatch.setenv("NOTEBOOKS", str(tmp_path / "notebook"))
 
     outside_path = (tmp_path / "outside" / TEST_CONFIG_SQLITE).resolve()
     outside_path.parent.mkdir()
@@ -154,12 +154,12 @@ def test_access_store_absolute_path_outside_base_is_displayed_absolute(
 def test_access_store_relative_input_falls_back_to_cwd(tmp_path, monkeypatch):
     """
     Test that relative input resolves against the current working directory when
-    neither root_dir nor NOTEBOOK_DIR is available.
+    neither root_dir nor NOTEBOOKS is available.
     """
     monkeypatch.chdir(tmp_path)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
-    monkeypatch.delenv("NOTEBOOK_DIR", raising=False)
+    monkeypatch.delenv("NOTEBOOKS", raising=False)
 
     ui = access_ui.get_access_store()
     file_name_field = ui.children[0].children[1].children[1]
@@ -182,12 +182,12 @@ def test_access_store_relative_input_is_resolved_against_notebook_dir(
 ):
     """
     Test that a relative file path entered in the UI is resolved against
-    NOTEBOOK_DIR and stored as an absolute path.
+    NOTEBOOKS and stored as an absolute path.
     """
     monkeypatch.chdir(tmp_path)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
-    monkeypatch.setenv("NOTEBOOK_DIR", str(tmp_path))
+    monkeypatch.setenv("NOTEBOOKS", str(tmp_path))
 
     ui = access_ui.get_access_store()
     file_name_field = ui.children[0].children[1].children[1]

--- a/test/unit/ui/access/test_access_store.py
+++ b/test/unit/ui/access/test_access_store.py
@@ -15,12 +15,14 @@ def test_access_store_ui_store_read_and_write(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
+    monkeypatch.delenv("NOTEBOOK_DIR", raising=False)
 
     if test_scs_file.exists():
         test_scs_file.unlink()
 
     assert access_ui.get_sb_store_file() == access_ui.DEFAULT_FILE_NAME
-    ui = access_ui.get_access_store(str(tmp_path))
+    ui = access_ui.get_access_store()
+    assert ui.children[0].children[1].children[1].value == access_ui.DEFAULT_FILE_NAME
     absolute_file_path = str((tmp_path / TEST_CONFIG_SQLITE).resolve())
     file_name_field = ui.children[0].children[1].children[1]
     file_name_field.value = absolute_file_path
@@ -30,30 +32,32 @@ def test_access_store_ui_store_read_and_write(tmp_path, monkeypatch):
     open_button.click()
     assert test_scs_file.read_text().strip() == absolute_file_path
     assert access_ui.get_sb_store_file() == absolute_file_path
+    assert file_name_field.value == TEST_CONFIG_SQLITE
 
-    ui_read = access_ui.get_access_store(str(tmp_path))
+    ui_read = access_ui.get_access_store()
     stored_name_field = ui_read.children[0].children[1].children[1]
-    assert stored_name_field.value == absolute_file_path
+    assert stored_name_field.value == TEST_CONFIG_SQLITE
 
 
 def test_access_store_legacy_relative_path_is_upgraded_to_absolute(
     tmp_path, monkeypatch
 ):
     """
-    Test that a legacy relative cache entry is resolved against root_dir and
+    Test that a legacy relative cache entry is resolved against NOTEBOOK_DIR and
     rewritten in absolute form after the store is opened.
     """
     monkeypatch.chdir(tmp_path)
     test_scs_file = tmp_path / "scs_file"
     monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
+    monkeypatch.setenv("NOTEBOOK_DIR", str(tmp_path))
 
     legacy_relative_path = "legacy_config.sqlite"
     test_scs_file.write_text(legacy_relative_path)
 
-    ui = access_ui.get_access_store(str(tmp_path))
+    ui = access_ui.get_access_store()
     file_name_field = ui.children[0].children[1].children[1]
     expected_absolute_path = str((tmp_path / legacy_relative_path).resolve())
-    assert file_name_field.value == expected_absolute_path
+    assert file_name_field.value == legacy_relative_path
 
     password_field = ui.children[0].children[2].children[1]
     password_field.value = "password"
@@ -61,3 +65,113 @@ def test_access_store_legacy_relative_path_is_upgraded_to_absolute(
     open_button.click()
 
     assert test_scs_file.read_text().strip() == expected_absolute_path
+    assert access_ui.get_sb_store_file() == expected_absolute_path
+    assert file_name_field.value == legacy_relative_path
+
+
+def test_access_store_explicit_root_dir_overrides_notebook_dir(
+    tmp_path, monkeypatch
+):
+    """
+    Test that an explicit root_dir is preferred over NOTEBOOK_DIR for display and
+    resolution.
+    """
+    monkeypatch.chdir(tmp_path)
+    test_scs_file = tmp_path / "scs_file"
+    monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
+    monkeypatch.setenv("NOTEBOOK_DIR", str(tmp_path / "notebook"))
+
+    explicit_root_dir = tmp_path / "explicit-root"
+    explicit_root_dir.mkdir()
+    relative_file_path = "explicit.sqlite"
+    test_scs_file.write_text(relative_file_path)
+
+    ui = access_ui.get_access_store(str(explicit_root_dir))
+    file_name_field = ui.children[0].children[1].children[1]
+    expected_absolute_path = str((explicit_root_dir / relative_file_path).resolve())
+    assert file_name_field.value == relative_file_path
+
+    password_field = ui.children[0].children[2].children[1]
+    password_field.value = "password"
+    open_button = ui.children[1]
+    open_button.click()
+
+    assert test_scs_file.read_text().strip() == expected_absolute_path
+    assert access_ui.get_sb_store_file() == expected_absolute_path
+    assert file_name_field.value == relative_file_path
+
+
+def test_access_store_absolute_path_outside_base_is_displayed_absolute(
+    tmp_path, monkeypatch
+):
+    """
+    Test that an absolute path outside the base directory stays absolute in the UI.
+    """
+    monkeypatch.chdir(tmp_path)
+    test_scs_file = tmp_path / "scs_file"
+    monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
+    monkeypatch.setenv("NOTEBOOK_DIR", str(tmp_path / "notebook"))
+
+    outside_path = (tmp_path / "outside" / TEST_CONFIG_SQLITE).resolve()
+    outside_path.parent.mkdir()
+    test_scs_file.write_text(str(outside_path))
+
+    ui = access_ui.get_access_store()
+    file_name_field = ui.children[0].children[1].children[1]
+    assert file_name_field.value == str(outside_path)
+
+
+def test_access_store_relative_input_falls_back_to_cwd(
+    tmp_path, monkeypatch
+):
+    """
+    Test that relative input resolves against the current working directory when
+    neither root_dir nor NOTEBOOK_DIR is available.
+    """
+    monkeypatch.chdir(tmp_path)
+    test_scs_file = tmp_path / "scs_file"
+    monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
+    monkeypatch.delenv("NOTEBOOK_DIR", raising=False)
+
+    ui = access_ui.get_access_store()
+    file_name_field = ui.children[0].children[1].children[1]
+    relative_file_path = "cwd_relative.sqlite"
+    file_name_field.value = relative_file_path
+
+    password_field = ui.children[0].children[2].children[1]
+    password_field.value = "password"
+    open_button = ui.children[1]
+    open_button.click()
+
+    expected_absolute_path = str((tmp_path / relative_file_path).resolve())
+    assert file_name_field.value == relative_file_path
+    assert test_scs_file.read_text().strip() == expected_absolute_path
+    assert access_ui.get_sb_store_file() == expected_absolute_path
+
+
+def test_access_store_relative_input_is_resolved_against_notebook_dir(
+    tmp_path, monkeypatch
+):
+    """
+    Test that a relative file path entered in the UI is resolved against
+    NOTEBOOK_DIR and stored as an absolute path.
+    """
+    monkeypatch.chdir(tmp_path)
+    test_scs_file = tmp_path / "scs_file"
+    monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
+    monkeypatch.setenv("NOTEBOOK_DIR", str(tmp_path))
+
+    ui = access_ui.get_access_store()
+    file_name_field = ui.children[0].children[1].children[1]
+    relative_file_path = "entered_relative.sqlite"
+    file_name_field.value = relative_file_path
+
+    password_field = ui.children[0].children[2].children[1]
+    password_field.value = "password"
+    open_button = ui.children[1]
+    open_button.click()
+
+    expected_absolute_path = str((tmp_path / relative_file_path).resolve())
+    assert file_name_field.value == relative_file_path
+    assert test_scs_file.read_text().strip() == expected_absolute_path
+    assert access_ui.get_sb_store_file() == expected_absolute_path

--- a/test/unit/ui/access/test_access_store.py
+++ b/test/unit/ui/access/test_access_store.py
@@ -34,3 +34,30 @@ def test_access_store_ui_store_read_and_write(tmp_path, monkeypatch):
     ui_read = access_ui.get_access_store(str(tmp_path))
     stored_name_field = ui_read.children[0].children[1].children[1]
     assert stored_name_field.value == absolute_file_path
+
+
+def test_access_store_legacy_relative_path_is_upgraded_to_absolute(
+    tmp_path, monkeypatch
+):
+    """
+    Test that a legacy relative cache entry is resolved against root_dir and
+    rewritten in absolute form after the store is opened.
+    """
+    monkeypatch.chdir(tmp_path)
+    test_scs_file = tmp_path / "scs_file"
+    monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
+
+    legacy_relative_path = "legacy_config.sqlite"
+    test_scs_file.write_text(legacy_relative_path)
+
+    ui = access_ui.get_access_store(str(tmp_path))
+    file_name_field = ui.children[0].children[1].children[1]
+    expected_absolute_path = str((tmp_path / legacy_relative_path).resolve())
+    assert file_name_field.value == expected_absolute_path
+
+    password_field = ui.children[0].children[2].children[1]
+    password_field.value = "password"
+    open_button = ui.children[1]
+    open_button.click()
+
+    assert test_scs_file.read_text().strip() == expected_absolute_path

--- a/test/unit/ui/access/test_access_store.py
+++ b/test/unit/ui/access/test_access_store.py
@@ -102,6 +102,39 @@ def test_access_store_explicit_root_dir_overrides_notebook_dir(
     assert file_name_field.value == relative_file_path
 
 
+def test_access_store_relative_root_dir_is_resolved_to_absolute(
+    tmp_path, monkeypatch
+):
+    """
+    Test that a relative root_dir is resolved against cwd before the store path is
+    joined and persisted.
+    """
+    notebooks_dir = tmp_path / "notebooks"
+    notebooks_dir.mkdir()
+    monkeypatch.chdir(notebooks_dir)
+    test_scs_file = tmp_path / "scs_file"
+    monkeypatch.setattr(access_ui, "get_scs_location_file_path", lambda: test_scs_file)
+    monkeypatch.delenv("NOTEBOOK_DIR", raising=False)
+
+    relative_root_dir = ".."
+    relative_file_path = "relative-root.sqlite"
+    test_scs_file.write_text(relative_file_path)
+
+    ui = access_ui.get_access_store(relative_root_dir)
+    file_name_field = ui.children[0].children[1].children[1]
+    expected_absolute_path = str((tmp_path / relative_file_path).resolve())
+    assert file_name_field.value == relative_file_path
+
+    password_field = ui.children[0].children[2].children[1]
+    password_field.value = "password"
+    open_button = ui.children[1]
+    open_button.click()
+
+    assert test_scs_file.read_text().strip() == expected_absolute_path
+    assert access_ui.get_sb_store_file() == expected_absolute_path
+    assert file_name_field.value == relative_file_path
+
+
 def test_access_store_absolute_path_outside_base_is_displayed_absolute(
     tmp_path, monkeypatch
 ):

--- a/test/unit/ui/access/test_access_store.py
+++ b/test/unit/ui/access/test_access_store.py
@@ -70,9 +70,7 @@ def test_access_store_legacy_relative_path_is_upgraded_to_absolute(
     assert file_name_field.value == legacy_relative_path
 
 
-def test_access_store_explicit_root_dir_overrides_notebook_dir(
-    tmp_path, monkeypatch
-):
+def test_access_store_explicit_root_dir_overrides_notebook_dir(tmp_path, monkeypatch):
     """
     Test that an explicit root_dir is preferred over NOTEBOOK_DIR for display and
     resolution.
@@ -102,9 +100,7 @@ def test_access_store_explicit_root_dir_overrides_notebook_dir(
     assert file_name_field.value == relative_file_path
 
 
-def test_access_store_relative_root_dir_is_resolved_to_absolute(
-    tmp_path, monkeypatch
-):
+def test_access_store_relative_root_dir_is_resolved_to_absolute(tmp_path, monkeypatch):
     """
     Test that a relative root_dir is resolved against cwd before the store path is
     joined and persisted.
@@ -155,9 +151,7 @@ def test_access_store_absolute_path_outside_base_is_displayed_absolute(
     assert file_name_field.value == str(outside_path)
 
 
-def test_access_store_relative_input_falls_back_to_cwd(
-    tmp_path, monkeypatch
-):
+def test_access_store_relative_input_falls_back_to_cwd(tmp_path, monkeypatch):
     """
     Test that relative input resolves against the current working directory when
     neither root_dir nor NOTEBOOK_DIR is available.


### PR DESCRIPTION
Resolves #417.

Access-store paths are normalized to absolute paths when read from or written to the cache. Relative values are resolved against the effective notebook base directory: an explicit `root_dir` passed to `get_access_store()` wins, otherwise the notebook environment exported by `ai-lab start` via `NOTEBOOKS` is used. The resolved value is written back as an absolute path.

`ai-lab start` now exports `NOTEBOOKS` to the launched JupyterLab process so notebooks and the access-store UI share the same base directory contract.

The UI still displays the stored path relative to the active base when possible, and falls back to the absolute path when the store lies outside that base.

Validation:

- `poetry run pytest -q test/unit/cli/test_ai_lab.py -q`
- `poetry run pytest -q test/unit/ui/access/test_access_store.py -q`
- `poetry run pytest -q test/integration/ui/access/test_access_store.py::test_access_store_sets_ai_lab_config_in_ipython test/integration/ui/transformers/util/test_te_init_ui.py -q`