### PR TITLE
#421: Enable SaaS SLC deploy

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -22,3 +22,7 @@
 * #401: Split as stable and unstable in CI workflow for normal and large tests
 * #408: Removed sagemaker related code and tests
 * #410: Updated Documentation for CLIs and Python APIs in notebook-connector
+
+## Documentation
+
+* #421: Enable SaaS SLC deploy

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -23,6 +23,6 @@
 * #408: Removed sagemaker related code and tests
 * #410: Updated Documentation for CLIs and Python APIs in notebook-connector
 
-## Documentation
+## Features
 
 * #421: Enable SaaS SLC deploy

--- a/exasol/nb_connector/resources/notebooks/script_languages_container/configure_slc_repository.ipynb
+++ b/exasol/nb_connector/resources/notebooks/script_languages_container/configure_slc_repository.ipynb
@@ -30,27 +30,25 @@
     "display(access_store.get_access_store('../'))"
    ]
   },
-  {
-   "cell_type": "markdown",
-   "id": "b81b0103-1014-4bc9-8724-0c0bafa83a23",
-   "metadata": {},
-   "source": [
-    "### Check that we don't have a SaaS backend configured"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "95d1e0e1-e334-4154-91cd-765d78868eaa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from exasol.nb_connector.ui.common import popup_message\n",
-    "from exasol.nb_connector.ai_lab_config import StorageBackend, AILabConfig\n",
-    "if ai_lab_config.get(AILabConfig.storage_backend, ) == StorageBackend.saas.name:\n",
-    "    popup_message.display_popup(f\"This tutorial will not work correctly with a SaaS as backend. You can export the Script-Languages-Container to a local file, but the upload to the database will fail.\")\n"
-   ]
-  },
+   {
+    "cell_type": "markdown",
+    "id": "b81b0103-1014-4bc9-8724-0c0bafa83a23",
+    "metadata": {},
+    "source": [
+    "### Check the configured backend"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "id": "95d1e0e1-e334-4154-91cd-765d78868eaa",
+    "metadata": {},
+    "outputs": [],
+    "source": [
+    "from exasol.nb_connector.ai_lab_config import AILabConfig\n",
+    "print(f\"Configured backend: {ai_lab_config.get(AILabConfig.storage_backend)}\")\n"
+    ]
+   },
   {
    "cell_type": "markdown",
    "id": "1adb7d2770b9906e",

--- a/exasol/nb_connector/resources/notebooks/script_languages_container/configure_slc_repository.ipynb
+++ b/exasol/nb_connector/resources/notebooks/script_languages_container/configure_slc_repository.ipynb
@@ -30,28 +30,9 @@
     "display(access_store.get_access_store('../'))"
    ]
   },
-   {
-    "cell_type": "markdown",
-    "id": "b81b0103-1014-4bc9-8724-0c0bafa83a23",
-    "metadata": {},
-    "source": [
-    "### Check the configured backend"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "id": "95d1e0e1-e334-4154-91cd-765d78868eaa",
-    "metadata": {},
-    "outputs": [],
-    "source": [
-    "from exasol.nb_connector.ai_lab_config import AILabConfig\n",
-    "print(f\"Configured backend: {ai_lab_config.get(AILabConfig.storage_backend)}\")\n"
-    ]
-   },
   {
-   "cell_type": "markdown",
-   "id": "1adb7d2770b9906e",
+    "cell_type": "markdown",
+    "id": "1adb7d2770b9906e",
    "metadata": {},
    "source": [
     "## Specific Configuration for this Tutorial\n",

--- a/exasol/nb_connector/resources/notebooks/script_languages_container/using_the_script_languages_container_tool.ipynb
+++ b/exasol/nb_connector/resources/notebooks/script_languages_container/using_the_script_languages_container_tool.ipynb
@@ -10,9 +10,7 @@
     "</div>\n",
     "\n",
     "# Using the Script-Languages Container Tool\n",
-    "A [Script-Language Container](https://github.com/exasol/script-languages-release)(SLC) for the Exasol database consists of a Linux container with a complete Linux distribution and all required libraries, such as a script client. The script client is responsible for the communication with the  database and for executing the script code. It allows to also include user specific libraries which can then be used from within the UDFs.\n",
-    "\n",
-    "**Note: This tutorial supports both on-prem and SaaS backends.**"
+    "A [Script-Language Container](https://github.com/exasol/script-languages-release)(SLC) for the Exasol database consists of a Linux container with a complete Linux distribution and all required libraries, such as a script client. The script client is responsible for the communication with the  database and for executing the script code. It allows to also include user specific libraries which can then be used from within the UDFs.\n"
    ]
   },
   {

--- a/exasol/nb_connector/resources/notebooks/script_languages_container/using_the_script_languages_container_tool.ipynb
+++ b/exasol/nb_connector/resources/notebooks/script_languages_container/using_the_script_languages_container_tool.ipynb
@@ -12,7 +12,7 @@
     "# Using the Script-Languages Container Tool\n",
     "A [Script-Language Container](https://github.com/exasol/script-languages-release)(SLC) for the Exasol database consists of a Linux container with a complete Linux distribution and all required libraries, such as a script client. The script client is responsible for the communication with the  database and for executing the script code. It allows to also include user specific libraries which can then be used from within the UDFs.\n",
     "\n",
-    "**Note: This tutorial currently does not support a SaaS backend.**"
+    "**Note: This tutorial supports both on-prem and SaaS backends.**"
    ]
   },
   {

--- a/exasol/nb_connector/slc/script_language_container.py
+++ b/exasol/nb_connector/slc/script_language_container.py
@@ -258,7 +258,9 @@ class ScriptLanguageContainer:
         return tls_params
 
     def _backend(self) -> StorageBackend:
-        storage_backend = self.secrets.get(CKey.storage_backend, StorageBackend.onprem.name)
+        storage_backend = self.secrets.get(
+            CKey.storage_backend, StorageBackend.onprem.name
+        )
         if storage_backend is None:
             return StorageBackend.onprem
         if isinstance(storage_backend, StorageBackend):

--- a/exasol/nb_connector/slc/script_language_container.py
+++ b/exasol/nb_connector/slc/script_language_container.py
@@ -27,6 +27,7 @@ from exasol_integration_test_docker_environment.lib.docker import (
 )
 
 from exasol.nb_connector.ai_lab_config import AILabConfig as CKey
+from exasol.nb_connector.ai_lab_config import StorageBackend
 from exasol.nb_connector.luigi_utils import (
     temporarily_disable_luigi_worker_shutdown_handler,
 )
@@ -239,46 +240,76 @@ class ScriptLanguageContainer:
                     compression_strategy=self.compression_strategy,
                 )
 
-    def _generate_bfs_params_from_secret_store(self):
-        bfs_params: dict[str, Any] = {
-            k: self.secrets.get(v)
-            for k, v in [
-                ("bucketfs_host", CKey.bfs_host_name),
-                ("bucketfs_port", CKey.bfs_port),
-                ("bucketfs_user", CKey.bfs_user),
-                ("bucketfs_password", CKey.bfs_password),
-                ("bucketfs_name", CKey.bfs_service),
-                ("bucket", CKey.bfs_bucket),
-            ]
-        }
+    def _generate_tls_params(self) -> dict[str, Any]:
+        tls_params: dict[str, Any] = {}
 
         bucketfs_use_https = optional_str_to_bool(self.secrets.get(CKey.bfs_encryption))
         if bucketfs_use_https is not None:
-            bfs_params["bucketfs_use_https"] = bucketfs_use_https
+            tls_params["bucketfs_use_https"] = bucketfs_use_https
+
         use_ssl_cert_validation = optional_str_to_bool(self.secrets.get(CKey.cert_vld))
         if use_ssl_cert_validation is not None:
-            bfs_params["use_ssl_cert_validation"] = use_ssl_cert_validation
+            tls_params["use_ssl_cert_validation"] = use_ssl_cert_validation
+
         ssl_cert_path = self.secrets.get(CKey.trusted_ca)
         if ssl_cert_path is not None:
-            bfs_params["ssl_cert_path"] = ssl_cert_path
-        return bfs_params
+            tls_params["ssl_cert_path"] = ssl_cert_path
+
+        return tls_params
+
+    def _backend(self) -> StorageBackend:
+        storage_backend = self.secrets.get(CKey.storage_backend, StorageBackend.onprem.name)
+        if storage_backend is None:
+            return StorageBackend.onprem
+        if isinstance(storage_backend, StorageBackend):
+            return storage_backend
+        return StorageBackend[storage_backend]
+
+    def _generate_deploy_params(self) -> dict[str, Any]:
+        deploy_params: dict[str, Any] = {
+            "path_in_bucket": constants.PATH_IN_BUCKET,
+            "release_name": self.language_alias,
+            "output_directory": str(self.workspace.output_path),
+            "compression_strategy": self.compression_strategy,
+        }
+        deploy_params.update(self._generate_tls_params())
+
+        if self._backend() == StorageBackend.saas:
+            deploy_params.update(
+                {
+                    "saas_host": self.secrets[CKey.saas_url],
+                    "saas_pat": self.secrets[CKey.saas_token],
+                    "saas_account_id": self.secrets[CKey.saas_account_id],
+                    "saas_database_id": self.secrets.get(CKey.saas_database_id),
+                    "saas_database_name": self.secrets.get(CKey.saas_database_name),
+                }
+            )
+            return deploy_params
+
+        deploy_params.update(
+            {
+                "bucketfs_host": self.secrets[CKey.bfs_host_name],
+                "bucketfs_port": self.secrets[CKey.bfs_port],
+                "bucketfs_user": self.secrets[CKey.bfs_user],
+                "bucketfs_password": self.secrets[CKey.bfs_password],
+                "bucketfs_name": self.secrets[CKey.bfs_service],
+                "bucket": self.secrets[CKey.bfs_bucket],
+            }
+        )
+        return deploy_params
 
     def deploy(self):
         """
         Deploys the current script-languages-container to the database and
         stores the activation string in the Secure Configuration Storage.
         """
-        bfs_params = self._generate_bfs_params_from_secret_store()
+        deploy_params = self._generate_deploy_params()
 
         with current_directory(self.checkout_dir):
             with temporarily_disable_luigi_worker_shutdown_handler():
                 result = exaslct_api.deploy(
                     flavor_path=(str(self._flavor_path_rel),),
-                    **bfs_params,
-                    path_in_bucket=constants.PATH_IN_BUCKET,
-                    release_name=self.language_alias,
-                    output_directory=str(self.workspace.output_path),
-                    compression_strategy=self.compression_strategy,
+                    **deploy_params,
                 )
             deploy_result = result[self._flavor_path_rel]["release"]
             builder = deploy_result.language_definition_builder
@@ -314,13 +345,18 @@ class ScriptLanguageContainer:
         but the script-language-container was uploaded to the BucketFS.
         Then it will register the Language activation for this SLC in the Secure Configuration Store.
         """
-        bfs_params = self._generate_bfs_params_from_secret_store()
+        if self._backend() == StorageBackend.saas:
+            bucketfs_name = "uploads"
+            bucket_name = "default"
+        else:
+            bucketfs_name = self.secrets[CKey.bfs_service]
+            bucket_name = self.secrets[CKey.bfs_bucket]
 
         with current_directory(self.checkout_dir):
             builder = get_language_definition_builder(
                 flavor_path=str(self._flavor_path_rel),
-                bucketfs_name=bfs_params["bucketfs_name"],
-                bucket_name=bfs_params["bucket"],
+                bucketfs_name=bucketfs_name,
+                bucket_name=bucket_name,
                 path_in_bucket=constants.PATH_IN_BUCKET,
                 container_name=f"{self.flavor}-release-{self.language_alias}",  # Currently this can't be retrieved from exaslct. Need to use a hard coded value here.
             )

--- a/nb_tests.yaml
+++ b/nb_tests.yaml
@@ -42,6 +42,9 @@ normal:
       - name: Cloud notebook (saas)
         test_file: test_cloud.py
         test_backend: saas
+      - name: SLC notebook (saas)
+        test_file: test_script_languages_container.py
+        test_backend: saas
       - name: sklearn notebook (saas)
         test_file: test_sklearn.py
         test_backend: saas

--- a/test/notebooks/test_script_languages_container.py
+++ b/test/notebooks/test_script_languages_container.py
@@ -28,6 +28,8 @@ def test_script_languages_container(
         run_notebook("configure_slc_repository.ipynb", store_file, store_password)
         run_notebook("export_as_is.ipynb", store_file, store_password)
         run_notebook("customize.ipynb", store_file, store_password)
+        # The sleep is needed because SaaS takes long for the synchronization of the SLC 
+        # and at the moment we don't have a better way to wait for it.
         if backend == "saas":
             time.sleep(10 * 60)
         run_notebook("test_slc.ipynb", store_file, store_password)

--- a/test/notebooks/test_script_languages_container.py
+++ b/test/notebooks/test_script_languages_container.py
@@ -4,22 +4,19 @@ from pathlib import Path
 from test.integration.ui.common.utils.notebook_test_utils import run_notebook
 
 import pytest
-from exasol.pytest_backend import BACKEND_ONPREM
 
 
 @pytest.fixture()
 def cleanup_slc_repo_dir(backend, notebooks_root):
     yield
-    if backend == BACKEND_ONPREM:
-        p = notebooks_root / "script_languages_container" / "slc_workspace"
+    p = notebooks_root / "script_languages_container" / "slc_workspace"
+    if p.exists():
         shutil.rmtree(p)
 
 
 def test_script_languages_container(
     backend, backend_setup, cleanup_slc_repo_dir, notebooks_root
 ) -> None:
-    if backend != BACKEND_ONPREM:
-        pytest.skip()
     current_dir = Path.cwd()
     store_path, store_password = backend_setup
     store_file = str(store_path)

--- a/test/notebooks/test_script_languages_container.py
+++ b/test/notebooks/test_script_languages_container.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from pathlib import Path
 from test.integration.ui.common.utils.notebook_test_utils import run_notebook
-
+import time
 import pytest
 
 
@@ -27,6 +27,8 @@ def test_script_languages_container(
         run_notebook("configure_slc_repository.ipynb", store_file, store_password)
         run_notebook("export_as_is.ipynb", store_file, store_password)
         run_notebook("customize.ipynb", store_file, store_password)
+        if backend == "saas":
+            time.sleep(10*60)
         run_notebook("test_slc.ipynb", store_file, store_password)
         run_notebook("advanced.ipynb", store_file, store_password)
         run_notebook(

--- a/test/notebooks/test_script_languages_container.py
+++ b/test/notebooks/test_script_languages_container.py
@@ -1,8 +1,9 @@
 import os
 import shutil
+import time
 from pathlib import Path
 from test.integration.ui.common.utils.notebook_test_utils import run_notebook
-import time
+
 import pytest
 
 
@@ -28,7 +29,7 @@ def test_script_languages_container(
         run_notebook("export_as_is.ipynb", store_file, store_password)
         run_notebook("customize.ipynb", store_file, store_password)
         if backend == "saas":
-            time.sleep(10*60)
+            time.sleep(10 * 60)
         run_notebook("test_slc.ipynb", store_file, store_password)
         run_notebook("advanced.ipynb", store_file, store_password)
         run_notebook(

--- a/test/notebooks/test_script_languages_container.py
+++ b/test/notebooks/test_script_languages_container.py
@@ -28,7 +28,7 @@ def test_script_languages_container(
         run_notebook("configure_slc_repository.ipynb", store_file, store_password)
         run_notebook("export_as_is.ipynb", store_file, store_password)
         run_notebook("customize.ipynb", store_file, store_password)
-        # The sleep is needed because SaaS takes long for the synchronization of the SLC 
+        # The sleep is needed because SaaS takes long for the synchronization of the SLC
         # and at the moment we don't have a better way to wait for it.
         if backend == "saas":
             time.sleep(10 * 60)

--- a/test/unit/slc/utest_slc.py
+++ b/test/unit/slc/utest_slc.py
@@ -713,9 +713,7 @@ def test_generate_activation_key_for_saas(
         language_definition_builder.generate_definition_components.return_value = [
             Mock(alias="original_alias"),
         ]
-        language_definition_builder.generate_definition.return_value = (
-            "custom_slc_CUDA=localzmq+protobuf:///uploads/default/container/Strawberry-release-custom_slc_CUDA?lang=python#buckets/uploads/default/container/Strawberry-release-custom_slc_CUDA/exaudf/exaudfclient"
-        )
+        language_definition_builder.generate_definition.return_value = "custom_slc_CUDA=localzmq+protobuf:///uploads/default/container/Strawberry-release-custom_slc_CUDA?lang=python#buckets/uploads/default/container/Strawberry-release-custom_slc_CUDA/exaudf/exaudfclient"
         builder_mock = Mock(return_value=language_definition_builder)
         monkeypatch.setattr(
             script_language_container, "get_language_definition_builder", builder_mock

--- a/test/unit/slc/utest_slc.py
+++ b/test/unit/slc/utest_slc.py
@@ -26,6 +26,7 @@ from exasol.exaslpm.model.package_file_config import (
 from exasol.slc.models.compression_strategy import CompressionStrategy
 
 from exasol.nb_connector.ai_lab_config import AILabConfig as CKey
+from exasol.nb_connector.ai_lab_config import StorageBackend
 from exasol.nb_connector.slc import (
     constants,
     script_language_container,
@@ -692,6 +693,56 @@ def test_generate_activation_key(
             assert slc.secrets.get(slc._alias_key) is None
 
 
+@pytest.mark.parametrize("add_to_secret_store", [True, False])
+def test_generate_activation_key_for_saas(
+    add_to_secret_store,
+    sample_slc_name,
+    slc_factory_create,
+    monkeypatch: MonkeyPatch,
+):
+    flavor = "Strawberry"
+
+    with slc_factory_create.context(slc_name=sample_slc_name, flavor=flavor) as slc:
+        slc.secrets.save(CKey.saas_url, "https://mock-saas.exasol.com")
+        slc.secrets.save(CKey.saas_token, "pat")
+        slc.secrets.save(CKey.saas_account_id, "account-id")
+        slc.secrets.save(CKey.saas_database_name, "database-name")
+        slc.secrets.save(CKey.storage_backend, StorageBackend.saas.name)
+
+        language_definition_builder = Mock()
+        language_definition_builder.generate_definition_components.return_value = [
+            Mock(alias="original_alias"),
+        ]
+        language_definition_builder.generate_definition.return_value = (
+            "custom_slc_CUDA=localzmq+protobuf:///uploads/default/container/Strawberry-release-custom_slc_CUDA?lang=python#buckets/uploads/default/container/Strawberry-release-custom_slc_CUDA/exaudf/exaudfclient"
+        )
+        builder_mock = Mock(return_value=language_definition_builder)
+        monkeypatch.setattr(
+            script_language_container, "get_language_definition_builder", builder_mock
+        )
+
+        language_activation = slc.generate_activation_key(add_to_secret_store)
+        assert (
+            language_activation
+            == "custom_slc_CUDA=localzmq+protobuf:///uploads/default/container/Strawberry-release-custom_slc_CUDA?lang=python#buckets/uploads/default/container/Strawberry-release-custom_slc_CUDA/exaudf/exaudfclient"
+        )
+        builder_mock.assert_called_once_with(
+            flavor_path=str(slc._flavor_path_rel),
+            bucketfs_name="uploads",
+            bucket_name="default",
+            path_in_bucket=constants.PATH_IN_BUCKET,
+            container_name=f"{slc.flavor}-release-{slc.language_alias}",
+        )
+        language_definition_builder.add_custom_alias.assert_called_once_with(
+            "original_alias",
+            slc.language_alias,
+        )
+        if add_to_secret_store:
+            assert slc.secrets.get(slc._alias_key) == language_activation
+        else:
+            assert slc.secrets.get(slc._alias_key) is None
+
+
 def test_restore_public_package_file(
     sample_slc_name, slc_factory_create, git_access_mock
 ):
@@ -836,6 +887,57 @@ def test_deploy_uses_luigi_shutdown_handler_guard(
             release_name=slc.language_alias,
             output_directory=str(slc.workspace.output_path),
             compression_strategy=slc.compression_strategy,
+        )
+        language_definition_builder.add_custom_alias.assert_called_once_with(
+            "original_alias",
+            slc.language_alias,
+        )
+        assert slc.secrets.get(slc._alias_key) == "activation_sql"
+
+
+def test_deploy_uses_saas_parameters(
+    sample_slc_name,
+    slc_factory_create,
+    luigi_shutdown_handler_guard,
+    monkeypatch: MonkeyPatch,
+):
+    flavor = "Strawberry"
+    with slc_factory_create.context(slc_name=sample_slc_name, flavor=flavor) as slc:
+        slc.secrets.save(CKey.saas_url, "https://mock-saas.exasol.com")
+        slc.secrets.save(CKey.saas_token, "pat")
+        slc.secrets.save(CKey.saas_account_id, "account-id")
+        slc.secrets.save(CKey.saas_database_name, "database-name")
+        slc.secrets.save(CKey.storage_backend, StorageBackend.saas.name)
+
+        language_definition_builder = Mock()
+        language_definition_builder.generate_definition_components.return_value = [
+            Mock(alias="original_alias"),
+        ]
+        language_definition_builder.generate_definition.return_value = "activation_sql"
+        deploy_result = Mock(language_definition_builder=language_definition_builder)
+        deploy_mock = Mock(
+            return_value={
+                slc._flavor_path_rel: {"release": deploy_result},
+            }
+        )
+        monkeypatch.setattr(
+            script_language_container.exaslct_api, "deploy", deploy_mock
+        )
+
+        slc.deploy()
+
+        assert luigi_shutdown_handler_guard == ["enter", "exit"]
+        deploy_mock.assert_called_once_with(
+            flavor_path=(str(slc._flavor_path_rel),),
+            path_in_bucket=constants.PATH_IN_BUCKET,
+            release_name=slc.language_alias,
+            output_directory=str(slc.workspace.output_path),
+            compression_strategy=slc.compression_strategy,
+            saas_host="https://mock-saas.exasol.com",
+            saas_pat="pat",
+            saas_account_id="account-id",
+            saas_database_id=None,
+            saas_database_name="database-name",
         )
         language_definition_builder.add_custom_alias.assert_called_once_with(
             "original_alias",


### PR DESCRIPTION
## Summary

Enable SaaS deploy support for ScriptLanguageContainer and align the notebook/tutorial flow with that capability.

## Changes
- Make SLC deploy and activation-key generation backend-aware.
- Keep on-prem behavior unchanged.
- Allow the SLC notebook test to run under SaaS.
- Add the SaaS SLC tutorial to the normal unstable notebook matrix.

## Validation
- `poetry run pytest test/unit/slc/utest_slc.py -q`
- `poetry run -- nox -s get-notebook-tests -- --test-status unstable --test-classification normal`

Closes #421
